### PR TITLE
Implement sort countries by different impacted status

### DIFF
--- a/src/app/pages/countries/countries.component.html
+++ b/src/app/pages/countries/countries.component.html
@@ -4,6 +4,24 @@
 
   <div class="w-full" *ngIf="data">
     <div class="md:flex mb-6">
+      <div class="mr-4">
+        <label for="sort-by"></label>
+        <div class="relative">
+          <select
+          [(ngModel)]="sortBy"
+          class="bg-gray-200 shadow appearance-none border-2 border-gray-200 rounded pr-8 py-2 px-4 text-gray-700 leading-tight focus:outline-none focus:border-green-500"
+          id="sort-by"
+        >
+          <option value="">Trier par</option>
+          <option value="confirmed">Confirmé</option>
+          <option value="recovered">Guérison</option>
+          <option value="deaths">Mort</option>
+        </select>
+          <div class="pointer-events-none absolute inset-y-0 right-0 flex items-center my-4 px-2 text-gray-700">
+            <svg class="fill-current h-4 w-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M9.293 12.95l.707.707L15.657 8l-1.414-1.414L10 10.828 5.757 6.586 4.343 8z"/></svg>
+          </div>
+        </div>
+      </div>
       <div class="flex-1">
         <label for="inline-full-name"></label>
         <input
@@ -37,7 +55,7 @@
           </tr>
           </thead>
           <tbody class="bg-white">
-          <tr *ngFor="let country of data | filter : searchText" routerLink="/countries/{{ country.url }}" [state]="{data: {country: country}}">
+          <tr *ngFor="let country of data | filter : searchText : sortBy" routerLink="/countries/{{ country.url }}" [state]="{data: {country: country}}">
             <td class="px-6 py-4 whitespace-no-wrap border-b border-gray-200" >
                 <div class="flex items-center">
                   <div class="flex-shrink-0 h-10 w-10">

--- a/src/app/pages/countries/countries.component.ts
+++ b/src/app/pages/countries/countries.component.ts
@@ -12,7 +12,9 @@ export class CountriesComponent implements OnInit {
   loading: boolean;
   error = false;
   searchText: string;
+  sortBy: string = '';
   data: Case[];
+  filteredData: Case[];
 
   constructor(private apiService: ApiService) {
   }
@@ -26,6 +28,7 @@ export class CountriesComponent implements OnInit {
             d.url = encodeURI(`${d.countryRegion}--${d.long}--${d.lat}`).toLowerCase();
           });
           this.data = data;
+          this.filteredData = data;
           this.loading = false;
         }, e => {
           sweetAlert.fire(

--- a/src/app/pages/countries/filter.pipe.ts
+++ b/src/app/pages/countries/filter.pipe.ts
@@ -1,20 +1,32 @@
 import {Pipe, PipeTransform} from '@angular/core';
+import {Case} from 'src/app/api.model';
+
+const sortByCallback = (sortBy: string):  any => (a: Case, b: Case) => {
+  if (!a.hasOwnProperty(sortBy)){
+    throw new Error(`Field ${sortBy} doesn't exists`);
+  }
+  return b[sortBy] - a[sortBy];
+}
 
 @Pipe({
   name: 'filter'
 })
 export class FilterPipe implements PipeTransform {
+  transform(
+    items: any[],
+    searchText: string,
+    sortBy: string,
+  ): any[] {
+    let cleanedItems: any[] = items || [];
+    if (sortBy) {
+      cleanedItems = cleanedItems.sort(sortByCallback(sortBy))
+    }
+    if (searchText) {
+      cleanedItems = cleanedItems.filter(it => {
+        return it.countryRegion.toLowerCase().includes(searchText.toLowerCase());
+      })
+    }
 
-  transform(items: any[], searchText: string): any[] {
-    if (!items) {
-      return [];
-    }
-    if (!searchText) {
-      return items;
-    }
-    searchText = searchText.toLowerCase();
-    return items.filter(it => {
-      return it.countryRegion.toLowerCase().includes(searchText);
-    });
+    return cleanedItems;
   }
 }


### PR DESCRIPTION
### Title
Implement sort countries by different infection status

### Description
In order to avail to users the right information needed as some users might have interests in countries that are most impacted or have the most actives impacted people or again have a high rate of death.

This PR implements a sorting functionality to solve the above

### Tasks
- Adds sort countries by confirmed cases
- Adds sort countries by recovered cases
- Adds sort countries by death cases

### Related issues
- [Issue 2](https://github.com/devscast/covid19-client/issues/2)

### Screenshops
![image](https://user-images.githubusercontent.com/17350127/77462911-71237200-6e0d-11ea-910a-7c21cb549d69.png)

