### PR TITLE
Only display countries without regions

### DIFF
--- a/src/app/api.model.ts
+++ b/src/app/api.model.ts
@@ -34,7 +34,7 @@ export interface Case {
   active: number;
   admin2?: any;
   fips?: any;
-  combinedKey?: null;
+  combinedKey: string;
   iso2: string;
   iso3: string;
 }

--- a/src/app/pages/countries/countries.component.html
+++ b/src/app/pages/countries/countries.component.html
@@ -57,7 +57,7 @@
           <tbody class="bg-white">
             <tr
               *ngFor="let country of data | filter : searchText : sortBy | paginate: { itemsPerPage: 10, currentPage: currentPage }"
-              routerLink="/countries/{{ country.url }}" [state]="{data: {country: country}}">
+              routerLink="/countries/{{ country.iso2 || country.url }}" [state]="{data: {country: country}}">
               <td class="px-6 py-4 whitespace-no-wrap border-b border-gray-200">
                 <div class="flex items-center">
                   <div class="flex-shrink-0 h-10 w-10">

--- a/src/app/pages/countries/country/country.component.html
+++ b/src/app/pages/countries/country/country.component.html
@@ -4,12 +4,12 @@
   <div class="bg-white shadow overflow-hidden sm:rounded-lg" *ngIf="error">
     <div class="px-4 py-5 border-b border-gray-200 sm:px-6">
       <div class="">
-        <img class="h-10 w-10" src="https://www.countryflags.io/{{data.iso2}}/flat/64.png" alt="{{ data.countryRegion }}"/>
+        <img *ngIf="data.iso2" class="h-10 w-10" src="https://www.countryflags.io/{{data.iso2}}/flat/64.png" alt="{{ data.countryRegion }}"/>
         <span class="text-lg leading-6 font-medium text-gray-900 mt-5">
-          Désolé les données pour : {{data.countryRegion}} {{data.provinceState}}
+          {{'Désolé, les données pour' | translate}} : {{data.countryRegion}} {{data.provinceState}}
         </span> <br>
         <span class="text-md text-gray-600">
-          Sont temporairement indisponibles, consultez la carte ou réessayez plus tard.
+          {{'Sont temporairement indisponibles, consultez la carte ou réessayez plus tard.' | translate}}
         </span>
       </div>
     </div>
@@ -22,14 +22,14 @@
         <span>{{ data.countryRegion }} {{data.provinceState}}</span>
       </h3>
       <p class="mt-1 max-w-2xl text-sm leading-5 text-gray-500">
-        {{ data.iso2 }}
+        {{ data.iso2 || 'N/A' }}
       </p>
     </div>
     <div>
       <dl>
         <div class="bg-gray-50 px-4 py-5 sm:grid sm:grid-cols-3 sm:gap-4 sm:px-6">
           <dt class="text-sm leading-5 font-medium text-gray-500">
-            Confirmés
+            {{'Confirmés' | translate}}
           </dt>
           <dd class="mt-1 text-sm leading-5 text-gray-900 sm:mt-0 sm:col-span-2">
             {{ data.confirmed }}
@@ -37,7 +37,7 @@
         </div>
         <div class="bg-white px-4 py-5 sm:grid sm:grid-cols-3 sm:gap-4 sm:px-6">
           <dt class="text-sm leading-5 font-medium text-gray-500">
-            Guérisons
+            {{'Guérisons' | translate}}
           </dt>
           <dd class="mt-1 text-sm leading-5 text-gray-900 sm:mt-0 sm:col-span-2">
             {{ data.recovered }}
@@ -45,15 +45,15 @@
         </div>
         <div class="bg-gray-50 px-4 py-5 sm:grid sm:grid-cols-3 sm:gap-4 sm:px-6">
           <dt class="text-sm leading-5 font-medium text-gray-500">
-            Morts
+            {{'Morts' | translate}}
           </dt>
           <dd class="mt-1 text-sm leading-5 text-gray-900 sm:mt-0 sm:col-span-2">
             {{ data.deaths }}
           </dd>
         </div>
         <div class="bg-white px-4 py-5 sm:grid sm:grid-cols-3 sm:gap-4 sm:px-6">
-          <span class="text-grey-700 text-lg font-bold">Mise à jour : {{ updatedAt }}</span> <br>
-          <span class="text-gray-500 text-md">Actualisation toutes les 3 heures.</span>
+          <span class="text-grey-700 text-lg font-bold">{{'Mise à jour' | translate}} : {{ updatedAt }}</span> <br>
+          <span class="text-gray-500 text-md">{{'Actualisation toutes les 3 heures.' | translate}}</span>
         </div>
       </dl>
     </div>

--- a/src/app/pages/countries/country/country.component.ts
+++ b/src/app/pages/countries/country/country.component.ts
@@ -20,7 +20,7 @@ export class CountryComponent implements OnInit, OnDestroy {
   constructor(private route: ActivatedRoute, private apiService: ApiService) {
     this.route.params.subscribe(p => {
       this.params = p;
-      if (typeof history.state.data.country !== 'undefined') {
+      if (history.state.data && typeof history.state.data.country !== 'undefined') {
         this.data = history.state.data.country;
       }
     });
@@ -36,7 +36,8 @@ export class CountryComponent implements OnInit, OnDestroy {
       .subscribe(
         data => {
           const country = data.find(d => {
-            return encodeURI(`${d.countryRegion}--${d.long}--${d.lat}`).toLowerCase() === this.params.id;
+            return encodeURI(`${d.countryRegion}--${d.long}--${d.lat}`).toLowerCase() === this.params.id
+            || d.iso2 === this.params.id;
           });
           if (country) {
             this.data = country;


### PR DESCRIPTION
### Title
Only display countries without regions or sub-regions

### Description
The countries' page was also displaying regions mixed with countries. This PR tries to clean data and only display countries

### Issues
- [Issue 10](https://github.com/devscast/covid19-client/issues/10)

### Screenshot
#### Countries page
![image](https://user-images.githubusercontent.com/17350127/77665275-1d896380-6f88-11ea-830a-db2e6d6e6899.png)


#### Single country page
![image](https://user-images.githubusercontent.com/17350127/77668920-b91cd300-6f8c-11ea-9b73-8527856ae248.png)




